### PR TITLE
Containerized the server for dev and  prod environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+build
+env
+dbdata

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/
 
 node_modules/
-
+dbdata/
 .env

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,6 @@
+FROM node:14-slim
+WORKDIR /usr/src/app
+COPY ./package*.json ./
+RUN npm install
+EXPOSE 5000
+CMD [ "npm", "start" ]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,19 @@
+#stage 1 building
+
+FROM node:14-slim as builder
+WORKDIR /usr/src/app
+COPY ./package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+#stage 2 serving
+
+FROM node:14-slim 
+WORKDIR /usr/src/app
+COPY ./package*.json ./
+RUN npm install --production
+COPY --from=builder /usr/src/app/build ./build
+COPY .env .
+EXPOSE 5000
+CMD ["npm", "run", "serve"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: server-dev
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    networks:
+      - app-network
+
+  db:
+    image: mongo
+    container_name: db-dev
+    restart: unless-stopped
+    volumes:
+      - ./dbdata:/data/db
+    networks:
+      - app-network
+    ports:
+      - "27017:27017"
+
+networks:
+  app-network:
+    driver: bridge

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,10 +15,11 @@ export const db = {
 
 export const corsURL: string = process.env.CORS_URL || '';
 
+const localConnectionURL = `mongodb://localhost:27017/${db.name}`;
 const devConnectionURL = `mongodb://db:27017/${db.name}`;
 const prodConnectionURL = `mongodb+srv://${db.user}:${encodeURIComponent(db.password)}@${db.host}.aewjs.mongodb.net/${db.name}?retryWrites=true&w=majority`;
 
-export const connectionURL: string = environment === 'production' ? prodConnectionURL : devConnectionURL;
+export const connectionURL: string = environment === 'production' ? prodConnectionURL : (environment === 'development' ? devConnectionURL : localConnectionURL);
 
 export const publicEncryptionKey: string = process.env.PUBLIC_ENCRYPTION_KEY || '';
 export const publicEncryptionIV: string = process.env.PUBLIC_ENCRYPTION_IV || '';

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export const db = {
 
 export const corsURL: string = process.env.CORS_URL || '';
 
-const devConnectionURL = `mongodb://localhost:27017/${db.name}`;
+const devConnectionURL = `mongodb://db:27017/${db.name}`;
 const prodConnectionURL = `mongodb+srv://${db.user}:${encodeURIComponent(db.password)}@${db.host}.aewjs.mongodb.net/${db.name}?retryWrites=true&w=majority`;
 
 export const connectionURL: string = environment === 'production' ? prodConnectionURL : devConnectionURL;


### PR DESCRIPTION

- I have created two separate Docker files for dev and prod environment
### Development Environment
- In order to run the server in dev environment, update `NODE_ENV` to `development` in `.env` file and run the following command in root directory of project - `docker-compose -f docker-compose-dev.yml up`
### Production Environment
- In order to run the server in prod environment, update `NODE_ENV` to `production`  along with MongoAtlas variables in `.env` file and run the following command in root directory of project - `docker build -t rocketmeet-server:prod -f Dockerfile.prod .`
- The above command will create a production based docker image of your server which you can confirm by using `docker images`
- To start the server, you need to run a container based on the above image, use the following command - 
    `docker container run -it -p 5000:5000 rocketmeet-server:prod`

### Local Environment

- If you still wish to work on your local environment (without Docker), update `NODE_ENV` to `local` in `.env` file and start the server in the respective environment according to [Read me](https://github.com/RocketMeet/RocketMeet-server/blob/main/README.md)
